### PR TITLE
support ObjectExpression properties without a `type` member

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -217,7 +217,7 @@
     }
 
     function replace(top, visitor) {
-        var worklist, leavelist, node, target, tuple, ret, current, current2, candidates, candidate, marker = {}, result;
+        var worklist, leavelist, node, nodeType, target, tuple, ret, current, current2, candidates, candidate, marker = {}, result;
 
         result = {
             top: top
@@ -251,6 +251,13 @@
             } else if (tuple[0]) {
                 ret = undefined;
                 node = tuple[0];
+
+                nodeType = node.type;
+                if (wrappers.hasOwnProperty(nodeType)) {
+                    tuple[0] = node = node.node;
+                    nodeType = wrappers[nodeType];
+                }
+
                 if (visitor.enter) {
                     target = visitor.enter(tuple[0], leavelist[leavelist.length - 1][0], notify);
                     if (target !== undefined) {
@@ -269,7 +276,7 @@
                     leavelist.push(tuple);
 
                     if (ret !== VisitorOption.Skip) {
-                        candidates = VisitorKeys[node.type];
+                        candidates = VisitorKeys[nodeType];
                         current = candidates.length;
                         while ((current -= 1) >= 0) {
                             candidate = node[candidates[current]];
@@ -278,7 +285,11 @@
                                     current2 = candidate.length;
                                     while ((current2 -= 1) >= 0) {
                                         if (candidate[current2]) {
-                                            worklist.push([candidate[current2], candidate, current2]);
+                                            if(nodeType === Syntax.ObjectExpression && 'properties' === candidates[current] && null == candidates[current].type) {
+                                                worklist.push([{type: 'PropertyWrapper', node: candidate[current2]}, candidate, current2]);
+                                            } else {
+                                                worklist.push([candidate[current2], candidate, current2]);
+                                            }
                                         }
                                     }
                                 } else {


### PR DESCRIPTION
Fixes #4. Sorry, no tests since there's no test suite. Here's what I was using to test it while developing:

``` javascript
estraverse = require('./estraverse.js')                                                                                      
esprima = require('esprima');

ast = esprima.parse('c = {a: b}');
delete ast.body[0].expression.right.properties[0].type;

estraverse.traverse(ast, {enter: function(node){ console.dir(node); }});
estraverse.replace(ast, {enter: function(node){ console.dir(node); return node; }});
```
