### PR TITLE
Fix to support UMD (Universal Module Definition) pattern

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -25,7 +25,7 @@
 /*jslint vars:false*/
 /*jshint indent:4*/
 /*global exports:true, define:true, window:true*/
-(function (factory) {
+(function (root, factory) {
     'use strict';
 
     // Universal Module Definition (UMD) to support AMD, CommonJS/Node.js,
@@ -35,9 +35,9 @@
     } else if (typeof exports !== 'undefined') {
         factory(exports);
     } else {
-        factory((window.estraverse = {}));
+        factory((root.estraverse = {}));
     }
-}(function (exports) {
+}(this, function (exports) {
     'use strict';
 
     var Syntax,


### PR DESCRIPTION
Fix support of UMD. See https://github.com/umdjs/umd/blob/master/returnExports.js

Estraverse could be used not only from browsers or nodejs, but also from embedded javascript engines (like V8). Such engines does not have global "window" variable. So global scope should be an argument in module definition.
