### PR TITLE
ArrowFunctionExpression -> ArrowExpression

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -50,7 +50,7 @@
     Syntax = {
         AssignmentExpression: 'AssignmentExpression',
         ArrayExpression: 'ArrayExpression',
-        ArrowFunctionExpression: 'ArrowFunctionExpression',
+        ArrowExpression: 'ArrowExpression',
         BlockStatement: 'BlockStatement',
         BinaryExpression: 'BinaryExpression',
         BreakStatement: 'BreakStatement',
@@ -177,7 +177,7 @@
     VisitorKeys = {
         AssignmentExpression: ['left', 'right'],
         ArrayExpression: ['elements'],
-        ArrowFunctionExpression: ['params', 'body'],
+        ArrowExpression: ['params', 'body'],
         BlockStatement: ['body'],
         BinaryExpression: ['left', 'right'],
         BreakStatement: ['label'],

--- a/test/traverse.coffee
+++ b/test/traverse.coffee
@@ -118,7 +118,7 @@ describe 'try statement', ->
 describe 'arrow function expression', ->
     it 'traverse', ->
         tree =
-            type: 'ArrowFunctionExpression'
+            type: 'ArrowExpression'
             params: [{
                 type: 'Identifier',
                 name: 'a'
@@ -128,11 +128,11 @@ describe 'arrow function expression', ->
                 body: []
 
         expect(Dumper.dump(tree)).to.be.equal """
-            enter - ArrowFunctionExpression
+            enter - ArrowExpression
             enter - Identifier
             leave - Identifier
             enter - BlockStatement
             leave - BlockStatement
-            leave - ArrowFunctionExpression
+            leave - ArrowExpression
         """
 


### PR DESCRIPTION
According to the parser API documentation, no node named `ArrowFunctionExpression` exists, but `ArrowExpression` does exist.
