### PR TITLE
estraverse breaking on comments inside conditions

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -648,7 +648,7 @@
 
                 while (cursor < comments.length) {
                     comment = comments[cursor];
-                    if (node.range[1] < comment.extendedRange[0]) {
+                    if (!node.range || node.range[1] < comment.extendedRange[0]) {
                         break;
                     }
 
@@ -668,7 +668,7 @@
                     return VisitorOption.Break;
                 }
 
-                if (comments[cursor].extendedRange[0] > node.range[1]) {
+                if (!node.range || comments[cursor].extendedRange[0] > node.range[1]) {
                     return VisitorOption.Skip;
                 }
             }


### PR DESCRIPTION
Example:

``` javascript
if (a &&
    // We need to check b beacuse of IE   <<< BOOM
    b > 0 && c) {
    // code
}
```

Trace:

```
/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/node_modules/escodegen/node_modules/estraverse/estraverse.js:646
                    if (node.range[1] < comment.extendedRange[0]) {
                                  ^
TypeError: Cannot read property '1' of undefined
    at Controller.traverse.leave (/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/node_modules/escodegen/node_modules/estraverse/estraverse.js:646:35)
    at Controller.__execute (/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/node_modules/escodegen/node_modules/estraverse/estraverse.js:313:31)
    at Controller.traverse (/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/node_modules/escodegen/node_modules/estraverse/estraverse.js:379:28)
    at traverse (/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/node_modules/escodegen/node_modules/estraverse/estraverse.js:551:27)
    at Object.attachComments (/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/node_modules/escodegen/node_modules/estraverse/estraverse.js:640:9)
    at Stream.end (/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/index.js:98:17)
    at _end (/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/node_modules/through/index.js:65:9)
    at Stream.stream.end (/Users/evindor/.nvm/v0.10.26/lib/node_modules/amd-to-closure/node_modules/through/index.js:74:5)
    at ReadStream.onend (_stream_readable.js:483:10)
    at ReadStream.g (events.js:180:16)
```

I've just hacked it around, i guess this issue needs more deep exploration.
