### PR TITLE
Remove overwriting node type.

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -506,7 +506,7 @@
                 }
 
                 node = element.node;
-                nodeType = element.wrap || node.type;
+                nodeType = node.type || element.wrap;
                 candidates = this.__keys[nodeType];
                 if (!candidates) {
                     if (this.__fallback) {
@@ -660,7 +660,7 @@
                 continue;
             }
 
-            nodeType = element.wrap || node.type;
+            nodeType = node.type || element.wrap;
             candidates = this.__keys[nodeType];
             if (!candidates) {
                 if (this.__fallback) {

--- a/test/traverse.coffee
+++ b/test/traverse.coffee
@@ -74,6 +74,25 @@ describe 'object expression', ->
             leave - ObjectExpression
         """
 
+    it 'properties with custom type', ->
+        tree =
+            type: 'ObjectExpression'
+            properties: [{
+                type: 'CustomProperty'
+                foo:
+                    type: 'Identifier'
+                    name: 'a'
+            }]
+
+        expect(Dumper.dump(tree, {CustomProperty: ['foo']})).to.be.equal """
+            enter - ObjectExpression
+            enter - CustomProperty
+            enter - Identifier
+            leave - Identifier
+            leave - CustomProperty
+            leave - ObjectExpression
+        """
+
     it 'skip and break', ->
         tree =
             type: 'ObjectExpression'


### PR DESCRIPTION
In estraverse, I can use custom node type. But when I used custom node type in `ObjectExpression.properties` or `ObjectPattern.properties`, that does not work as expected because the node type is overwritten as `Property`.

This behavior seemed to be added for #4. I thought to use `element.wrap` only when `node.type` is nothing is no problem.