### PR TITLE
Introduce 'recur' callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ coverage/
 
 npm-debug.log
 .vimrc.local
+
+/*.sublime-project
+/*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Think of this simple graph:
    /  \
   A    B
 ```
-With recur, the overall sequence of traversal will be: Enter Parent, Enter A, Leave A, Recur Parent, Enter B, Leave B, Leave Parent
+With recur, the overall sequence of traversal will be: Enter Parent, Enter A, Leave A, Recur Parent, Enter B, Leave B, Leave Parent.
 This can be useful to check, wether a node is actually a grandchild or a sibling of another node, which can be hard to detect with
 enter and leave alone.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,23 @@
-### Estraverse [![Build Status](https://secure.travis-ci.org/estools/estraverse.png)](http://travis-ci.org/estools/estraverse)
+### Estraverse Fork
+
+This fork introduces a 'recur' callback beside 'enter' and 'leave'. recur is called with the parent
+element between the traversal of its siblings.
+
+Think of this simple graph:
+
+```
+  Parent
+    /\
+   /  \
+  A    B
+```
+With recur, the overall sequence of traversal will be: Enter Parent, Enter A, Leave A, Recur Parent, Enter B, Leave B, Leave Parent
+This can be useful to check, wether a node is actually a grandchild or a sibling of another node, which can be hard to detect with
+enter and leave alone.
+
+Recur only supports BREAK. Also, within replace, recur does not support replacing or removing, only BREAK.
+
+The rest from here on is original documentation from estraverse.
 
 Estraverse ([estraverse](http://github.com/estools/estraverse)) is
 [ECMAScript](http://www.ecma-international.org/publications/standards/Ecma-262.htm)

--- a/estraverse.js
+++ b/estraverse.js
@@ -394,7 +394,7 @@
         this.__current = element;
         this.__state = null;
         if (callback) {
-            result = callback.call(this, element.node, this.__leavelist[this.__leavelist.length - 1].node);
+            result = callback.call(this, element.node, this.__leavelist[this.__leavelist.length - 1]);
         }
         this.__current = previous;
 
@@ -487,6 +487,15 @@
                 if (this.__state === BREAK || ret === BREAK) {
                     return;
                 }
+
+                if (worklist.length > 0 && worklist[worklist.length-1] !== sentinel) {
+                    ret = this.__execute(visitor.recur, leavelist[leavelist.length-1]);
+                }
+
+                if (this.__state === BREAK || ret === BREAK) {
+                    return;
+                }
+
                 continue;
             }
 
@@ -625,6 +634,15 @@
                 if (this.__state === BREAK || target === BREAK) {
                     return outer.root;
                 }
+
+                if (worklist.length > 0 && worklist[worklist.length-1] !== sentinel) {
+                    target = this.__execute(visitor.recur, leavelist[leavelist.length-1]);
+                }
+
+                if (this.__state === BREAK || target === BREAK) {
+                    return;
+                }
+
                 continue;
             }
 

--- a/estraverse.js
+++ b/estraverse.js
@@ -394,7 +394,7 @@
         this.__current = element;
         this.__state = null;
         if (callback) {
-            result = callback.call(this, element.node, this.__leavelist[this.__leavelist.length - 1]);
+            result = callback.call(this, element.node, this.__leavelist[this.__leavelist.length - 1].node);
         }
         this.__current = previous;
 

--- a/test/controller.coffee
+++ b/test/controller.coffee
@@ -45,6 +45,9 @@ describe 'controller', ->
             enter: (node) ->
                 dumper.log("enter - #{node.type}")
 
+            recur: (node) ->
+                dumper.log("recur - #{node.type}")
+
             leave: (node) ->
                 dumper.log("leave - #{node.type}")
 
@@ -53,6 +56,7 @@ describe 'controller', ->
             enter - undefined
             enter - Identifier
             leave - Identifier
+            recur - undefined
             enter - Identifier
             leave - Identifier
             leave - undefined

--- a/test/dumper.coffee
+++ b/test/dumper.coffee
@@ -42,6 +42,10 @@ module.exports = class Dumper
                 dumper.log("enter - #{node.type}")
                 VisitorOption[node.$enter]
 
+            recur: (node) ->
+                dumper.log("recur - #{node.type}")
+                VisitorOption[node.$recur]
+
             leave: (node) ->
                 dumper.log("leave - #{node.type}")
                 VisitorOption[node.$leave]

--- a/test/es6.coffee
+++ b/test/es6.coffee
@@ -66,12 +66,15 @@ describe 'class', ->
             enter - ClassDeclaration
             enter - Identifier
             leave - Identifier
+            recur - ClassDeclaration
             enter - Identifier
             leave - Identifier
+            recur - ClassDeclaration
             enter - ClassBody
             enter - MethodDefinition
             enter - Identifier
             leave - Identifier
+            recur - MethodDefinition
             enter - FunctionExpression
             enter - BlockStatement
             leave - BlockStatement
@@ -79,6 +82,7 @@ describe 'class', ->
             leave - MethodDefinition
             leave - ClassBody
             leave - ClassDeclaration
+            recur - Program
             enter - EmptyStatement
             leave - EmptyStatement
             leave - Program
@@ -97,14 +101,17 @@ describe 'class', ->
             enter - ClassDeclaration
             enter - Identifier
             leave - Identifier
+            recur - ClassDeclaration
             enter - CallExpression
             enter - Identifier
             leave - Identifier
             leave - CallExpression
+            recur - ClassDeclaration
             enter - ClassBody
             enter - MethodDefinition
             enter - Identifier
             leave - Identifier
+            recur - MethodDefinition
             enter - FunctionExpression
             enter - BlockStatement
             leave - BlockStatement
@@ -112,6 +119,7 @@ describe 'class', ->
             leave - MethodDefinition
             leave - ClassBody
             leave - ClassDeclaration
+            recur - Program
             enter - EmptyStatement
             leave - EmptyStatement
             leave - Program
@@ -142,6 +150,7 @@ describe 'export', ->
             enter - VariableDeclarator
             enter - Identifier
             leave - Identifier
+            recur - VariableDeclarator
             enter - Literal
             leave - Literal
             leave - VariableDeclarator
@@ -175,9 +184,11 @@ describe 'export', ->
             enter - ExportSpecifier
             enter - Identifier
             leave - Identifier
+            recur - ExportSpecifier
             enter - Identifier
             leave - Identifier
             leave - ExportSpecifier
+            recur - ExportNamedDeclaration
             enter - Literal
             leave - Literal
             leave - ExportNamedDeclaration
@@ -208,6 +219,7 @@ describe 'export', ->
             enter - ClassDeclaration
             enter - Identifier
             leave - Identifier
+            recur - ClassDeclaration
             enter - ClassBody
             leave - ClassBody
             leave - ClassDeclaration
@@ -224,6 +236,7 @@ describe 'export', ->
             enter - ClassDeclaration
             enter - Identifier
             leave - Identifier
+            recur - ClassDeclaration
             enter - ClassBody
             leave - ClassBody
             leave - ClassDeclaration
@@ -247,6 +260,7 @@ describe 'import', ->
             enter - Identifier
             leave - Identifier
             leave - ImportDefaultSpecifier
+            recur - ImportDeclaration
             enter - Literal
             leave - Literal
             leave - ImportDeclaration
@@ -267,15 +281,19 @@ describe 'import', ->
             enter - ImportSpecifier
             enter - Identifier
             leave - Identifier
+            recur - ImportSpecifier
             enter - Identifier
             leave - Identifier
             leave - ImportSpecifier
+            recur - ImportDeclaration
             enter - ImportSpecifier
             enter - Identifier
             leave - Identifier
+            recur - ImportSpecifier
             enter - Identifier
             leave - Identifier
             leave - ImportSpecifier
+            recur - ImportDeclaration
             enter - Literal
             leave - Literal
             leave - ImportDeclaration
@@ -297,6 +315,7 @@ describe 'import', ->
             enter - Identifier
             leave - Identifier
             leave - ImportNamespaceSpecifier
+            recur - ImportDeclaration
             enter - Literal
             leave - Literal
             leave - ImportDeclaration
@@ -320,6 +339,7 @@ describe 'pattern', ->
             enter - AssignmentPattern
             enter - Identifier
             leave - Identifier
+            recur - AssignmentPattern
             enter - Literal
             leave - Literal
             leave - AssignmentPattern
@@ -358,6 +378,7 @@ describe 'meta property', ->
             enter - MetaProperty
             enter - Identifier
             leave - Identifier
+            recur - MetaProperty
             enter - Identifier
             leave - Identifier
             leave - MetaProperty

--- a/test/replace.coffee
+++ b/test/replace.coffee
@@ -387,3 +387,33 @@ describe 'replace', ->
                     if node.type is 'Literal' and node.value is 2
                         VisitorOption.Remove
         .to.throw('Unknown node type XXXExpression.')
+
+    it 'supports recur without remove/replace', ->
+        log = ""
+        tree =
+            type: 'ObjectExpression'
+            properties: [{
+                type: 'Property'
+                key:
+                    type: 'Identifier'
+                    name: 'a'
+                value:
+                    type: 'BinaryExpression'
+                    operator: '*'
+                    left:
+                        type: 'Literal'
+                        value: 2
+                    right:
+                        type: 'Literal'
+                        value: 3
+            }]
+
+        tree = replace tree,
+            recur: (node) ->
+                log += node.type + "\n"
+
+        expect(log).to.be.equal """
+            Property
+            BinaryExpression
+            
+        """

--- a/test/traverse.coffee
+++ b/test/traverse.coffee
@@ -45,6 +45,7 @@ describe 'object expression', ->
             enter - Property
             enter - Identifier
             leave - Identifier
+            recur - Property
             enter - Identifier
             leave - Identifier
             leave - Property
@@ -68,6 +69,7 @@ describe 'object expression', ->
             enter - undefined
             enter - Identifier
             leave - Identifier
+            recur - undefined
             enter - Identifier
             leave - Identifier
             leave - undefined
@@ -121,9 +123,45 @@ describe 'object expression', ->
             enter - Property
             enter - Identifier
             leave - Identifier
+            recur - Property
             enter - ObjectExpression
             leave - ObjectExpression
             leave - Property
+        """
+
+    it 'break in recur', ->
+        tree =
+            type: 'ObjectExpression'
+            properties: [{
+                type: 'Property'
+                key:
+                    type: 'Identifier'
+                    name: 'a'
+                value:
+                    type: 'ObjectExpression'
+                    properties: [{
+                        type: 'Property'
+                        $recur: 'Break'
+                        key:
+                            type: 'Identifier'
+                            name: 'a'
+                        value:
+                            type: 'Identifier'
+                            name: 'a'
+                    }]
+            }]
+
+        expect(Dumper.dump(tree)).to.be.equal """
+            enter - ObjectExpression
+            enter - Property
+            enter - Identifier
+            leave - Identifier
+            recur - Property
+            enter - ObjectExpression
+            enter - Property
+            enter - Identifier
+            leave - Identifier
+            recur - Property
         """
 
 describe 'object pattern', ->
@@ -145,6 +183,7 @@ describe 'object pattern', ->
             enter - Property
             enter - Identifier
             leave - Identifier
+            recur - Property
             enter - Identifier
             leave - Identifier
             leave - Property
@@ -168,6 +207,7 @@ describe 'object pattern', ->
             enter - undefined
             enter - Identifier
             leave - Identifier
+            recur - undefined
             enter - Identifier
             leave - Identifier
             leave - undefined
@@ -190,6 +230,7 @@ describe 'try statement', ->
             enter - TryStatement
             enter - BlockStatement
             leave - BlockStatement
+            recur - TryStatement
             enter - BlockStatement
             leave - BlockStatement
             leave - TryStatement
@@ -210,6 +251,7 @@ describe 'try statement', ->
             enter - TryStatement
             enter - BlockStatement
             leave - BlockStatement
+            recur - TryStatement
             enter - BlockStatement
             leave - BlockStatement
             leave - TryStatement
@@ -247,13 +289,16 @@ describe 'arrow function expression', ->
             enter - AssignmentPattern
             enter - Identifier
             leave - Identifier
+            recur - AssignmentPattern
             enter - Literal
             leave - Literal
             leave - AssignmentPattern
+            recur - ArrowFunctionExpression
             enter - RestElement
             enter - Identifier
             leave - Identifier
             leave - RestElement
+            recur - ArrowFunctionExpression
             enter - BlockStatement
             leave - BlockStatement
             leave - ArrowFunctionExpression
@@ -290,13 +335,16 @@ describe 'function expression', ->
             enter - AssignmentPattern
             enter - Identifier
             leave - Identifier
+            recur - AssignmentPattern
             enter - Literal
             leave - Literal
             leave - AssignmentPattern
+            recur - FunctionExpression
             enter - RestElement
             enter - Identifier
             leave - Identifier
             leave - RestElement
+            recur - FunctionExpression
             enter - BlockStatement
             leave - BlockStatement
             leave - FunctionExpression
@@ -336,16 +384,20 @@ describe 'function declaration', ->
             enter - FunctionDeclaration
             enter - Identifier
             leave - Identifier
+            recur - FunctionDeclaration
             enter - AssignmentPattern
             enter - Identifier
             leave - Identifier
+            recur - AssignmentPattern
             enter - Literal
             leave - Literal
             leave - AssignmentPattern
+            recur - FunctionDeclaration
             enter - RestElement
             enter - Identifier
             leave - Identifier
             leave - RestElement
+            recur - FunctionDeclaration
             enter - BlockStatement
             leave - BlockStatement
             leave - FunctionDeclaration
@@ -381,12 +433,16 @@ describe 'extending keys', ->
             enter - TestStatement
             enter - Identifier
             leave - Identifier
+            recur - TestStatement
             enter - Identifier
             leave - Identifier
+            recur - TestStatement
             enter - Literal
             leave - Literal
+            recur - TestStatement
             enter - Identifier
             leave - Identifier
+            recur - TestStatement
             enter - BlockStatement
             leave - BlockStatement
             leave - TestStatement
@@ -421,12 +477,16 @@ describe 'no listed keys fallback', ->
             enter - TestStatement
             enter - Identifier
             leave - Identifier
+            recur - TestStatement
             enter - Identifier
             leave - Identifier
+            recur - TestStatement
             enter - Literal
             leave - Literal
+            recur - TestStatement
             enter - Identifier
             leave - Identifier
+            recur - TestStatement
             enter - BlockStatement
             leave - BlockStatement
             leave - TestStatement


### PR DESCRIPTION
Hi,

for my projects, I felt the need for an in-order callback during tree traversal.
(e.g. https://en.wikipedia.org/wiki/Tree_traversal -> in-order)

This pull request introduces a 'recur' callback beside 'enter' and 'leave'. recur is called with the parent element between the traversal of its siblings.

Think of this simple graph:

```
  Parent
    /\
   /  \
  A    B
```
With recur, the overall sequence of traversal will be: Enter Parent, Enter A, Leave A, Recur Parent, Enter B, Leave B, Leave Parent. This, beside other usecases, can be useful to check, wether a node is actually a grandchild or a sibling of another node, which can be hard to detect with enter and leave alone.

Recur here only supports BREAK. Also, within replace, recur does not support replacing or removing, only BREAK.

It is just a little addition, but perhaps you find it useful, too.

Cheers,
Sven