### PR TITLE
Add support for inline comments

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -773,7 +773,19 @@
                 while (cursor < comments.length) {
                     comment = comments[cursor];
                     if (comment.extendedRange[1] > node.range[0]) {
-                        break;
+                      // Collect inline comments
+                      if (comment.extendedRange[0] < node.range[1]) { // Don't handle trailing comment which starts after the node 
+                        if ((node.type === Syntax.ObjectExpression && node.properties.length === 0) ||
+                          (node.type === Syntax.BlockStatement && node.body.length === 0)) {
+                          if (!node.inlineComments) {
+                            node.inlineComments = [];
+                          }
+                          node.inlineComments.push(comment);
+                          comments.splice(cursor, 1);
+                          continue;			
+                        }
+                      }
+                      break;
                     }
 
                     if (comment.extendedRange[1] === node.range[0]) {


### PR DESCRIPTION
In regard to issue #206 ("Attach comment to an empty object"):

I have an initial modification of attachComments() and addComments() which supports comments in empty object/block.

I've called them inline comments, and they are attached to the node which represents the empty object/block (i.e. ObjectExpression/BlockStatement).