### PR TITLE
Add .babelrc into .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 npm-debug.log
+.babelrc
 .DS_Store
 .vimrc.local
 t.js


### PR DESCRIPTION
Currently, estraverse includes `.babelrc` in published files, which causes a problem when using a babel plugin depending on estraverse without babel-preset-es2015. (e.g. [babel-preset-espower](https://github.com/power-assert-js/babel-plugin-espower))

* https://github.com/estools/estraverse/blob/master/.babelrc#L2

This PR is to remove `.babelrc` from published files because it is required only in testing.
