### PR TITLE
Build: use babel-preset-env.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-    "presets": ["es2015"]
+    "presets": ["env"]
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "babel-preset-env": "^1.6.0",
-    "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "chai": "^2.1.1",
     "espree": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "http://github.com/estools/estraverse.git"
   },
   "devDependencies": {
-    "babel-preset-env": "^1.6.0",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "^6.3.13",
     "chai": "^2.1.1",
     "espree": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "url": "http://github.com/estools/estraverse.git"
   },
   "devDependencies": {
+    "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "chai": "^2.1.1",


### PR DESCRIPTION
babel-preset-es2015 is no longer maintained.