### PR TITLE
feat: support addComments with fallback iteration

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -726,7 +726,8 @@
                 if (comments[cursor].extendedRange[0] > node.range[1]) {
                     return VisitorOption.Skip;
                 }
-            }
+            },
+            fallback: 'iteration'
         });
 
         cursor = 0;
@@ -759,7 +760,8 @@
                 if (comments[cursor].extendedRange[0] > node.range[1]) {
                     return VisitorOption.Skip;
                 }
-            }
+            },
+            fallback: 'iteration'
         });
 
         return tree;


### PR DESCRIPTION
`estraverse.addComments()` not support some syntax like `dynamic import`.

If using `estraverse.traverse()`, can solve this problem with setting `fallback='iteration'`, but not supported in just calling `estraverse.addComments()`
