### PR TITLE
Support dynamic import

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -108,6 +108,7 @@
         GeneratorExpression: 'GeneratorExpression',  // CAUTION: It's deferred to ES7.
         Identifier: 'Identifier',
         IfStatement: 'IfStatement',
+        Import: 'ImportExpression',
         ImportDeclaration: 'ImportDeclaration',
         ImportDefaultSpecifier: 'ImportDefaultSpecifier',
         ImportNamespaceSpecifier: 'ImportNamespaceSpecifier',
@@ -182,6 +183,7 @@
         GeneratorExpression: ['blocks', 'filter', 'body'],  // CAUTION: It's deferred to ES7.
         Identifier: [],
         IfStatement: ['test', 'consequent', 'alternate'],
+        Import: ['argument'],
         ImportDeclaration: ['specifiers', 'source'],
         ImportDefaultSpecifier: ['local'],
         ImportNamespaceSpecifier: ['local'],

--- a/test/es6.js
+++ b/test/es6.js
@@ -320,6 +320,36 @@ describe('import', function() {
     });
 });
 
+describe.skip('dynamic import', function() {
+  it('expression pattern #1', function() {
+      const tree = espree(`import('rabbit-house')`, {
+          ecmaFeatures: {
+              modules: true
+          }
+      });
+
+      checkDump(Dumper.dump(tree), `
+          enter - Program
+          enter - ImportExpression
+          leave - Program
+      `);
+  });
+
+  it('expression pattern #1', function() {
+      const tree = espree(`import(\`module-\${foo}\`)`, {
+          ecmaFeatures: {
+              modules: true
+          }
+      });
+
+      checkDump(Dumper.dump(tree), `
+          enter - Program
+          enter - ImportExpression
+          leave - Program
+      `);
+  });
+});
+
 describe('pattern', function() {
     it('assignment pattern#1', function() {
         const tree = {

--- a/test/es6.js
+++ b/test/es6.js
@@ -320,34 +320,37 @@ describe('import', function() {
     });
 });
 
-describe.skip('dynamic import', function() {
-  it('expression pattern #1', function() {
-      const tree = espree(`import('rabbit-house')`, {
-          ecmaFeatures: {
-              modules: true
-          }
-      });
+describe('dynamic import', function() {
+    it('expression pattern #1', function() {
+        // TODO: espree currently doesn't support dynamic imports. Update when it does
+        // const tree = espree(`import('rabbit-house')`, {
+        //     ecmaFeatures: {
+        //         modules: true
+        //     }
+        // });
+
+        const tree = {
+            type: 'CallExpression',
+            callee: {
+                type: 'Import'
+            },
+            arguments: [
+                {
+                    type: 'Literal',
+                    value: 'rabbit-house'
+                }
+            ]
+        };
 
       checkDump(Dumper.dump(tree), `
-          enter - Program
-          enter - ImportExpression
-          leave - Program
+          enter - CallExpression
+          enter - Import
+          leave - Import
+          enter - Literal
+          leave - Literal
+          leave - CallExpression
       `);
-  });
-
-  it('expression pattern #1', function() {
-      const tree = espree(`import(\`module-\${foo}\`)`, {
-          ecmaFeatures: {
-              modules: true
-          }
-      });
-
-      checkDump(Dumper.dump(tree), `
-          enter - Program
-          enter - ImportExpression
-          leave - Program
-      `);
-  });
+    });
 });
 
 describe('pattern', function() {


### PR DESCRIPTION
Attempt to support https://tc39.github.io/proposal-dynamic-import/

I have a local setup where I run estraverse on the output of [Acorn](https://www.npmjs.com/package/acorn) with the [acorn-dynamic-import](https://www.npmjs.com/package/acorn-dynamic-import) installed through estraverse with this patch applied. That works fine.

I added some commented out tests, which are not working at the moment. This is primarily because espree doesn't know how to parse dynamic imports yet. The tests are probably not correct either because I'm not fully aware of the expected behavior

Relates to #98 

--- Update ---
I switched the tests to avoid the espree dependency, which enables them to pass