### PR TITLE
prevent infinite traversal when passed cyclic structures

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -388,19 +388,17 @@
     function isProperty(nodeType, key) {
         return (nodeType === Syntax.ObjectExpression || nodeType === Syntax.ObjectPattern) && 'properties' === key;
     }
+  
+    function candidateExistsInLeaveList(leavelist, candidate) {
+        for (var i = leavelist.length - 1; i >= 0; --i) {
+            if (leavelist[i].node === candidate) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     Controller.prototype.traverse = function traverse(root, visitor) {
-        function candidateExistInLeaveList(leavelist, candidate) {
-          var current = leavelist.length;
-          var exist;
-
-          while((current -= 1) >= 0 && !exist) {
-            exist = leavelist[current] && leavelist[current].node === candidate;
-          }
-
-          return exist;
-        }
-
         var worklist,
             leavelist,
             element,
@@ -482,7 +480,7 @@
                                 continue;
                             }
 
-                            if (candidateExistInLeaveList(leavelist, candidate[current2])) {
+                            if (candidateExistsInLeaveList(leavelist, candidate[current2])) {
                               continue;
                             }
 
@@ -496,7 +494,7 @@
                             worklist.push(element);
                         }
                     } else if (isNode(candidate)) {
-                        if (candidateExistInLeaveList(leavelist, candidate)) {
+                        if (candidateExistsInLeaveList(leavelist, candidate)) {
                           continue;
                         }
 

--- a/estraverse.js
+++ b/estraverse.js
@@ -390,6 +390,17 @@
     }
 
     Controller.prototype.traverse = function traverse(root, visitor) {
+        function candidateExistInLeaveList(leavelist, candidate) {
+          var current = leavelist.length;
+          var exist;
+
+          while((current -= 1) >= 0 && !exist) {
+            exist = leavelist[current] && leavelist[current].node === candidate;
+          }
+
+          return exist;
+        }
+
         var worklist,
             leavelist,
             element,
@@ -458,6 +469,7 @@
                 current = candidates.length;
                 while ((current -= 1) >= 0) {
                     key = candidates[current];
+
                     candidate = node[key];
                     if (!candidate) {
                         continue;
@@ -469,6 +481,11 @@
                             if (!candidate[current2]) {
                                 continue;
                             }
+
+                            if (candidateExistInLeaveList(leavelist, candidate[current2])) {
+                              continue;
+                            }
+
                             if (isProperty(nodeType, candidates[current])) {
                                 element = new Element(candidate[current2], [key, current2], 'Property', null);
                             } else if (isNode(candidate[current2])) {
@@ -479,6 +496,10 @@
                             worklist.push(element);
                         }
                     } else if (isNode(candidate)) {
+                        if (candidateExistInLeaveList(leavelist, candidate)) {
+                          continue;
+                        }
+
                         worklist.push(new Element(candidate, key, null, null));
                     }
                 }

--- a/estraverse.js
+++ b/estraverse.js
@@ -467,7 +467,6 @@
                 current = candidates.length;
                 while ((current -= 1) >= 0) {
                     key = candidates[current];
-
                     candidate = node[key];
                     if (!candidate) {
                         continue;

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -559,4 +559,28 @@ describe('no listed keys fallback', function() {
           () => traverse(tree, { enter(node) {} })
         ).to.throw('Unknown node type XXXExpression.');
     });
+
+    it('break loop', function () {
+        const children = {
+          type: 'Children',
+          name: 'div'
+        };
+
+        const parent = {
+          type: 'Parent',
+          name: children,
+          parent: null,
+        };
+
+        children.parent = parent;
+
+        const tree = parent;
+
+        checkDump(Dumper.dump(tree, null, 'iteration'), `
+              enter - Parent
+              enter - Children
+              leave - Children
+              leave - Parent
+          `);
+    })
 });


### PR DESCRIPTION
When traverse unlisted keys, `estraverse` will iteraction this node all properties.

I think in most cases the property `parent` is used to reference parent node.

So I exclude `parent` in iteraction.

This issue was discovered while using `esquery`, `esquery` use `estraverse` directly without set `fallback`.  
