### PR TITLE
Attach comments performance

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -732,10 +732,8 @@
                             node.leadingComments = [];
                         }
                         node.leadingComments.push(comment);
-                        comments.splice(cursor, 1);
-                    } else {
-                        cursor += 1;
                     }
+                    cursor++;
                 }
 
                 // already out of owned node
@@ -765,10 +763,8 @@
                             node.trailingComments = [];
                         }
                         node.trailingComments.push(comment);
-                        comments.splice(cursor, 1);
-                    } else {
-                        cursor += 1;
                     }
+                    cursor++;
                 }
 
                 // already out of owned node

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "ECMAScript JS AST traversal functions",
   "homepage": "https://github.com/estools/estraverse",
   "main": "estraverse.js",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Increase cursor instead of using splice on comments array, which is a very expensive operation and cause a performance issue for large files with many comments.

See issue:
https://github.com/estools/estraverse/issues/114