### PR TITLE
Add support to named ExportAllDeclaration

### DIFF
--- a/estraverse.js
+++ b/estraverse.js
@@ -172,7 +172,7 @@
         DirectiveStatement: [],
         DoWhileStatement: ['body', 'test'],
         EmptyStatement: [],
-        ExportAllDeclaration: ['source'],
+        ExportAllDeclaration: ['source', 'exported'],
         ExportDefaultDeclaration: ['declaration'],
         ExportNamedDeclaration: ['declaration', 'specifiers', 'source'],
         ExportSpecifier: ['exported', 'local'],

--- a/test/es6.js
+++ b/test/es6.js
@@ -209,6 +209,29 @@ describe('export', function() {
         `);
     });
 
+    it('all declaration #2 (named)', function() {
+        const tree = {
+            type: 'ExportAllDeclaration',
+            source: {
+                type: 'Literal',
+                value: 'hello'
+            },
+            exported: {
+                type: 'Identifier',
+                name: 'name1'
+            }
+        };
+
+        checkDump(Dumper.dump(tree), `
+            enter - ExportAllDeclaration
+            enter - Literal
+            leave - Literal
+            enter - Identifier
+            leave - Identifier
+            leave - ExportAllDeclaration
+        `);
+    });
+
     it('default declaration #1', function() {
         const tree = {
             type: 'ExportDefaultDeclaration',


### PR DESCRIPTION
In ES2020, support of named export has been added [1].
Traversing an ExportAllDeclaration previously missed its 'exported' key which is an identifier.

In this patchset, the traverse of the 'exported' key is added.

[1]: https://github.com/estree/estree/blob/master/es2020.md#exportalldeclaration